### PR TITLE
fix infinity display when arms data present but merch data missing

### DIFF
--- a/src/components/PercentageCircle.js
+++ b/src/components/PercentageCircle.js
@@ -5,7 +5,9 @@ import { PieChart, Pie, Label} from 'recharts';
 const PercentageCircle = ({percentage}) => {
 
     const translateAngle = (value) => {
+
         return (value/100) * -360 +90;
+
       }
 
     return (
@@ -28,7 +30,7 @@ const PercentageCircle = ({percentage}) => {
                 dataKey="value"
                 isAnimationActive={false}
                 startAngle={90}
-                endAngle={translateAngle(percentage)}
+                endAngle={Number.isFinite(percentage) ? translateAngle(percentage) : 90}
                 data={[{value: 1}]}
                 cx="50%"
                 cy="50%"
@@ -40,7 +42,7 @@ const PercentageCircle = ({percentage}) => {
                 <Label 
                     position="center"
                     >
-                    {!Number.isNaN(percentage) ? (Math.round(percentage) > 0 ?`${Math.round(percentage)}%` : "<1%") : "?%"}
+                    {!Number.isNaN(percentage) && Number.isFinite(percentage) ? (Math.round(percentage) > 0 ?`${Math.round(percentage)}%` : "<1%") : "?%"}
                     </Label>
                 </Pie>
 


### PR DESCRIPTION
Percentage used to be displayed is infinite if there was a value for arms exports, but none for mercahndise exports (due to 
division by 0)
