### PR TITLE
end to end

### DIFF
--- a/.github/workflows/staging.yaml
+++ b/.github/workflows/staging.yaml
@@ -86,3 +86,10 @@ jobs:
             - name: 'Apply plan'
               working-directory: ./terraform/staging
               run: terraform apply test-deploy.tfplan
+            - name: 'Get ip and port from outputs'
+              run: echo "$(tf output -raw public-ip):$(tf output -raw port)" > url.txt
+            - name: 'Upload url artifact'
+              uses: actions/upload-artifact@v3
+              with:
+                name: frontend-url
+                path: url.txt

--- a/.github/workflows/staging.yaml
+++ b/.github/workflows/staging.yaml
@@ -87,7 +87,9 @@ jobs:
               working-directory: ./terraform/staging
               run: terraform apply test-deploy.tfplan
             - name: 'Get ip and port from outputs'
-              run: echo "$(tf output -raw public-ip)" > url.txt
+              run: | 
+                echo "$(terraform output -raw public-ip)" > url.txt
+                cat url.txt
             - name: 'Upload url artifact'
               uses: actions/upload-artifact@v3
               with:

--- a/.github/workflows/staging.yaml
+++ b/.github/workflows/staging.yaml
@@ -87,7 +87,7 @@ jobs:
               working-directory: ./terraform/staging
               run: terraform apply test-deploy.tfplan
             - name: 'Get ip and port from outputs'
-              run: echo "$(tf output -raw public-ip):$(tf output -raw port)" > url.txt
+              run: echo "$(tf output -raw public-ip)" > url.txt
             - name: 'Upload url artifact'
               uses: actions/upload-artifact@v3
               with:

--- a/.github/workflows/staging.yaml
+++ b/.github/workflows/staging.yaml
@@ -87,6 +87,7 @@ jobs:
               working-directory: ./terraform/staging
               run: terraform apply test-deploy.tfplan
             - name: 'Get ip and port from outputs'
+              working-directory: ./terraform/staging
               run: | 
                 echo "$(terraform output -raw public-ip)" > url.txt
                 cat url.txt
@@ -94,4 +95,4 @@ jobs:
               uses: actions/upload-artifact@v3
               with:
                 name: frontend-url
-                path: url.txt
+                path: ./terraform/staging/url.txt

--- a/terraform/staging/outputs.tf
+++ b/terraform/staging/outputs.tf
@@ -1,0 +1,7 @@
+output "public-ip" {
+  value = azurerm_container_group.container-instance.ip_address
+}
+
+output "port" {
+  value = azurerm_container_group.container-instance.exposed_port
+}


### PR DESCRIPTION
- add public ip and exposed port to outputs
- upload frontend url as artifact
- only add public ip to artifact
