### PR TITLE
sidebar scaling fix

### DIFF
--- a/src/components/SideBarExports.jsx
+++ b/src/components/SideBarExports.jsx
@@ -43,7 +43,7 @@ const SideBarExports = ({countryData, collapsed, onCollapse, year, settings}) =>
                         <span className='circle-label' style={{width: collapsed ? '0' : '100%', }}>Percentage of Exports<sup>[1]</sup></span>
                     </div>
                 </div>
-                <div className="barPlot-title" style={{width: collapsed ? '0' : '100%'}}>{`Export Destination Countries ${year}`}</div>
+                <div className="barPlot-title" style={{width: collapsed ? '0' : '100%'}}>{`\n Export Destination Countries ${year}`}</div>
 
                 <div className="barPlot">
                     <ResponsiveContainer width={collapsed ? 0 : "100%"} height={countryData.exportSources.length*30+20}>

--- a/src/components/SideBarImports.css
+++ b/src/components/SideBarImports.css
@@ -114,7 +114,7 @@
     color: white;
     text-align: center;
     text-decoration: underline;
-
+    white-space: pre-line;
   }
 
 .sideBar .panel .barPlot {

--- a/src/components/SideBarImports.jsx
+++ b/src/components/SideBarImports.jsx
@@ -53,7 +53,7 @@ const SideBarImports = ({countryData, collapsed, onCollapse, year, settings}) =>
                         <span className='circle-label' style={{width: collapsed ? '0%' : '100%'}}>Peace Index <sup>[2]</sup></span>
                     </div>
                 </div>
-                <div className="barPlot-title" style={{width: collapsed ? '0' : '100%'}}>{`Import Source Countries ${year}`}</div>
+                <div className="barPlot-title" style={{width: collapsed ? '0' : '100%'}}>{`\n Import Source Countries ${year}`}</div>
                 <div className="barPlot">
                     <ResponsiveContainer width={collapsed ? 0 : "100%"} height={countryData.importSources.length*30+20}>
                     {countryData.importSources.value !== 'no data' ? 


### PR DESCRIPTION
fixes #89

- make title responsive
- fix scaling of barplot title
- fix min size for timeseries plot
- set fixed width for sidebar
- use jsx extension
- fix scaling of barplot title
- set fixed sidebar width for exports
- set min height for barplot for cases of little or no data
- add space between colo-coded viz and barplot title
