### PR TITLE
Fix tooltip stuck after mouse leaves Geography

### DIFF
--- a/src/components/MapTooltipExports.jsx
+++ b/src/components/MapTooltipExports.jsx
@@ -9,13 +9,13 @@ import { formatUSDvalue, formatUSDorder, getUSDColor } from "./formattingUtils";
  * @param {function} handleMouseEnterBox Function on parent that handles mouse being over the tooltip.
  * 
  */
-const MapTooltipExports = (hoveredCountry, handleMouseEnterBox, settings) => {
+const MapTooltipExports = (hoveredCountry, settings) => {
 
     return (
         <div>
             {hoveredCountry.totalArmsExports && 
             <div className="hover-box-container" style={{top: hoveredCountry.position.y +5, left: hoveredCountry.position.x +10,}}
-                onMouseEnter={handleMouseEnterBox}>
+                >
                     <h3>{hoveredCountry.countryName.value}</h3>
 
                     

--- a/src/components/MapTooltipImports.jsx
+++ b/src/components/MapTooltipImports.jsx
@@ -1,7 +1,7 @@
 import React from "react"
 import { formatUSDvalue, formatUSDorder, getDemocracyColor, getPeaceColor, getUSDColor } from "./formattingUtils"
 
-const MapTooltip = (hoveredCountry, handleMouseEnterBox, settings) => {
+const MapTooltip = (hoveredCountry, settings) => {
 
     //console.log(hoveredCountry)
     
@@ -9,7 +9,7 @@ const MapTooltip = (hoveredCountry, handleMouseEnterBox, settings) => {
         <div>
             {hoveredCountry.totalArmsImports &&
             <div className="hover-box-container" style={{top: hoveredCountry.position.y +5, left: hoveredCountry.position.x +10,}}
-                onMouseEnter={handleMouseEnterBox}>
+                >
                     <h3>{hoveredCountry.countryName.value}</h3>
 
                     

--- a/src/components/WorldMap.jsx
+++ b/src/components/WorldMap.jsx
@@ -61,7 +61,7 @@ const WorldMap = ({mapModeImport, year, activeCountryData, updateActiveCountry, 
     }
 
     // Ensures tooltip disappears as soon as Geography is left
-    handleMouseEnterBox()
+    setHoveredCountry(null)
   };
 
   // Track mouse over Geography
@@ -79,11 +79,6 @@ const WorldMap = ({mapModeImport, year, activeCountryData, updateActiveCountry, 
 
   };
 
-  // Mouse enter for hover tool. If the mouse hovers over the tooltip, is should act as if over no country
-  // Otherwise it would cause the value to get stuck if the mouse happens to leave the geomatry via the tooltip.
-  const handleMouseEnterBox = (event) => {
-    setHoveredCountry(null)
-  }
   
   // Get data for the tooltip if map mode is import
   const getImportTooltipData = async (alpha2) => {
@@ -242,7 +237,7 @@ const WorldMap = ({mapModeImport, year, activeCountryData, updateActiveCountry, 
                 <button className='button'
                     onClick={handleZoomOut}>-</button>
             </div>
-      {hoveredCountry && (mapModeImport ? MapTooltipImports(hoveredCountry, handleMouseEnterBox, settings) : MapTooltipExports(hoveredCountry, handleMouseEnterBox, settings))}
+      {hoveredCountry && (mapModeImport ? MapTooltipImports(hoveredCountry, settings) : MapTooltipExports(hoveredCountry, settings))}
     </div>
   );
 };


### PR DESCRIPTION
Previously the tooltip would get stuck after the mouse leaves a Geography. This is due to the function called upon entering the Geo being 
async and sometimes not having finished hen the mouse leaves the Geo. Leaving would trigger resetting the hoveredCountry object, but the 
still running onMouseEnter function would repopulate it. The not empty object would then cause the tooltip to still be displayed. 

The current solution is to have the onMouse move on the Map component reset the hoveredCountry object. This requires the Geography to have 
its own onMouseMove funcion that does the same thing, except resetting the hoveredCountry object. It also does not propagate the event so the 
parent elemetns onMouseMove does not get called (which would reset the object after all).

Additionally these cahnges remove the need for the added behavior on the tooltip that ensured the tolltip would disappear if the mouse entered its box.
