### PR TITLE
fix(ui): various accessabilit fixes

### DIFF
--- a/__tests__/App.test.js
+++ b/__tests__/App.test.js
@@ -47,9 +47,9 @@ test('changing the year slider updates the year passed down to the map', () => {
 test('the settings gear toggles the currency settings panel', () => {
   render(<App />);
   expect(screen.queryByText('Currency:')).not.toBeInTheDocument();
-  fireEvent.click(screen.getByAltText('Settings'));
+  fireEvent.click(screen.getByRole('button', { name: 'Settings' }));
   expect(screen.getByText('Currency:')).toBeInTheDocument();
-  fireEvent.click(screen.getByAltText('Settings'));
+  fireEvent.click(screen.getByRole('button', { name: 'Settings' }));
   expect(screen.queryByText('Currency:')).not.toBeInTheDocument();
 });
 

--- a/__tests__/Dropdown.test.js
+++ b/__tests__/Dropdown.test.js
@@ -10,27 +10,25 @@ const options = [
   { value: 'EUR', label: 'Euro' },
 ];
 
-test('shows a placeholder when no default value is given', () => {
+test('lists every option', () => {
   render(<Dropdown options={options} onSelect={() => {}} />);
-  expect(screen.getByText('Select language')).toBeInTheDocument();
+  expect(screen.getByRole('option', { name: 'US Dollar' })).toBeInTheDocument();
+  expect(screen.getByRole('option', { name: 'Euro' })).toBeInTheDocument();
 });
 
-test('shows the default value label when provided', () => {
-  render(<Dropdown options={options} onSelect={() => {}} defaultValue={options[0]} />);
-  expect(screen.getByText('US Dollar')).toBeInTheDocument();
+test('reflects the currently selected value', () => {
+  render(<Dropdown options={options} onSelect={() => {}} value={options[1]} />);
+  expect(screen.getByRole('combobox')).toHaveValue('EUR');
 });
 
-test('opens on click and lists all options', () => {
-  render(<Dropdown options={options} onSelect={() => {}} />);
-  fireEvent.click(screen.getByText('Select language'));
-  expect(screen.getByText('Euro')).toBeInTheDocument();
-});
-
-test('selecting an option calls onSelect and closes the list', () => {
+test('selecting a different option calls onSelect with it', () => {
   const onSelect = jest.fn();
-  render(<Dropdown options={options} onSelect={onSelect} />);
-  fireEvent.click(screen.getByText('Select language'));
-  fireEvent.click(screen.getByText('Euro'));
+  render(<Dropdown options={options} onSelect={onSelect} value={options[0]} />);
+  fireEvent.change(screen.getByRole('combobox'), { target: { value: 'EUR' } });
   expect(onSelect).toHaveBeenCalledWith(options[1]);
-  expect(screen.queryByText('US Dollar')).not.toBeInTheDocument();
+});
+
+test('is a real <select>, so it is reachable and operable by keyboard', () => {
+  render(<Dropdown options={options} onSelect={() => {}} value={options[0]} />);
+  expect(screen.getByRole('combobox').tagName).toBe('SELECT');
 });

--- a/__tests__/Settings.test.js
+++ b/__tests__/Settings.test.js
@@ -14,8 +14,7 @@ test('renders the currently selected currency', () => {
 test('selecting a new currency calls setSettings with the merged settings object', () => {
   const setSettings = jest.fn();
   render(<Settings settings={defaultSettings} setSettings={setSettings} />);
-  fireEvent.click(screen.getByText('US Dollar'));
-  fireEvent.click(screen.getByText('Euro'));
+  fireEvent.change(screen.getByRole('combobox'), { target: { value: 'EUR' } });
   expect(setSettings).toHaveBeenCalledWith({
     ...defaultSettings,
     currency: { value: 'EUR', label: 'Euro', symbol: '€' },
@@ -25,9 +24,22 @@ test('selecting a new currency calls setSettings with the merged settings object
 test('hovering the info icon shows the currency explanation, and hiding it removes it', () => {
   render(<Settings settings={defaultSettings} setSettings={() => {}} />);
   const infoText = /EUR is currency from original data/;
+  const infoButton = screen.getByRole('button', { name: 'Currency information' });
   expect(screen.queryByText(infoText)).not.toBeInTheDocument();
-  fireEvent.mouseOver(screen.getByAltText('i'));
+  fireEvent.mouseOver(infoButton);
   expect(screen.getByText(infoText)).toBeInTheDocument();
-  fireEvent.mouseOut(screen.getByAltText('i'));
+  fireEvent.mouseOut(infoButton);
+  expect(screen.queryByText(infoText)).not.toBeInTheDocument();
+});
+
+test('focusing the info icon via keyboard also shows the currency explanation', () => {
+  // Regression test for the accessibility fix: the info box used to only
+  // open on mouse hover, making it unreachable by keyboard.
+  render(<Settings settings={defaultSettings} setSettings={() => {}} />);
+  const infoText = /EUR is currency from original data/;
+  const infoButton = screen.getByRole('button', { name: 'Currency information' });
+  fireEvent.focus(infoButton);
+  expect(screen.getByText(infoText)).toBeInTheDocument();
+  fireEvent.blur(infoButton);
   expect(screen.queryByText(infoText)).not.toBeInTheDocument();
 });

--- a/src/App.css
+++ b/src/App.css
@@ -115,6 +115,17 @@
   text-decoration: underline;
 }
 
+.footer .column .footer-link button {
+  background: none;
+  border: none;
+  padding: 0;
+  margin: 0;
+  font: inherit;
+  color: inherit;
+  text-decoration: inherit;
+  cursor: inherit;
+}
+
 .country-data-status {
   position: fixed;
   top: 50px;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -155,13 +155,14 @@ function App() {
                 <img className='logo' src="/favicon.png" alt="Taro"/>
                 <div className='title'>Arms-Tracker</div>
                 <button className='settings-button'
+                    aria-label="Settings"
                     onClick={
                         (e) => {
                             e.stopPropagation();
                             setShowSettings(!showSettings)
                         }
                 }>
-                    <img className='settings-icon' src='/settings.png' alt="Settings"/>
+                    <img className='settings-icon' src='/settings.png' alt=""/>
                 </button>
             </div>
 
@@ -209,9 +210,9 @@ function App() {
 
             <div className='footer'>
                 <div className='column'>
-                    <span className="footer-link"><div onClick={() => {showPopUp==='data' ? setShowPopUp('none') : setShowPopUp('data')}}>Data Sources</div>
+                    <span className="footer-link"><button type="button" onClick={() => {showPopUp==='data' ? setShowPopUp('none') : setShowPopUp('data')}}>Data Sources</button>
                     </span>
-                    <span className="footer-link"><div  onClick={() => {showPopUp==='impressum' ? setShowPopUp('none') : setShowPopUp('impressum')}}>Impressum</div>
+                    <span className="footer-link"><button type="button" onClick={() => {showPopUp==='impressum' ? setShowPopUp('none') : setShowPopUp('impressum')}}>Impressum</button>
                     </span>
                 </div>
                 <div className='bar'/>

--- a/src/components/Dropdown.css
+++ b/src/components/Dropdown.css
@@ -1,14 +1,8 @@
 .dropdown {
     color: #ffffff;
     background-color: #242e41;
-    text-align: left;
-}
-
-.dropdown .dropdown-options {
-    border: 1px #ffffff;
-    padding: 0px;
-    overflow: visible;
-    height: 200%;
-}
-.dropdown .dropdown-option {
+    border: 1px solid #ffffff;
+    border-radius: 4px;
+    width: 100%;
+    padding: 2px 4px;
 }

--- a/src/components/Dropdown.jsx
+++ b/src/components/Dropdown.jsx
@@ -1,51 +1,31 @@
-import React, { useState } from 'react';
+import React from 'react';
 
 import './Dropdown.css'
 
 /**
- * Dropdown component for selecting an option from a list.
+ * Dropdown for selecting an option from a list. Backed by a native
+ * <select> so keyboard navigation (arrow keys, type-to-select) and screen
+ * reader semantics come for free instead of being reimplemented by hand.
  *
  * @param {Object} props - The component props.
  * @param {Array} props.options - An array of option objects, each containing a 'value' and 'label'.
  * @param {Function} props.onSelect - A callback function to handle the selected option.
+ * @param {Object} props.value - The currently selected option.
  */
-const Dropdown = ({ options, onSelect, defaultValue}) => {
-  // State to manage the selected option and dropdown open/close state.
-  const [selectedOption, setSelectedOption] = useState(defaultValue);
-  const [isOpen, setIsOpen] = useState(false);
-
-  // Toggle the dropdown open/close state.
-  const toggleDropdown = () => {
-    setIsOpen(!isOpen);
-  };
-
-  // Handle the selection of an option and close the dropdown.
-  const handleOptionClick = (option) => {
-    setSelectedOption(option);
-    onSelect(option);
-    setIsOpen(false);
+const Dropdown = ({ options, onSelect, value }) => {
+  const handleChange = (event) => {
+    const selected = options.find((option) => option.value === event.target.value);
+    onSelect(selected);
   };
 
   return (
-    <div className="dropdown">
-      <div className="dropdown-header" onClick={toggleDropdown}>
-        {selectedOption ? selectedOption.label : 'Select language'}
-        <i className={`arrow ${isOpen ? 'up' : 'down'}`}></i>
-      </div>
-      {isOpen && (
-        <ul className="dropdown-options">
-          {options.map((option) => (
-            <div
-              key={option.value}
-              className="dropdown-option"
-              onClick={() => handleOptionClick(option)}
-            >
-              {option.label}
-            </div>
-          ))}
-        </ul>
-      )}
-    </div>
+    <select className="dropdown" value={value ? value.value : ''} onChange={handleChange}>
+      {options.map((option) => (
+        <option key={option.value} value={option.value}>
+          {option.label}
+        </option>
+      ))}
+    </select>
   );
 };
 

--- a/src/components/PopUp.jsx
+++ b/src/components/PopUp.jsx
@@ -22,7 +22,7 @@ const PopUp = (content, setShowPopUp) => {
     return (
         <div className='popup-container' style={{width: boxWidth, marginLeft: boxLeftMargin}}>
             <div>{setShowPopUp.content}</div>
-            <button style={{ position: 'absolute', top: '5px', right: '5px', color: 'white', backgroundColor: '#374151', border: 'none', borderRadius: '10px', textAlign: 'center' }} onClick={() => { content.setShowPopUp('none') }}>X</button>
+            <button aria-label="Close" style={{ position: 'absolute', top: '5px', right: '5px', color: 'white', backgroundColor: '#374151', border: 'none', borderRadius: '10px', textAlign: 'center' }} onClick={() => { content.setShowPopUp('none') }}>X</button>
             <div>
                 {{
                     'impressum': <Impressum />,

--- a/src/components/Settings.css
+++ b/src/components/Settings.css
@@ -47,6 +47,10 @@
     width: 15%;
     display: flex;
     justify-content: center;
+    background: none;
+    border: none;
+    padding: 0;
+    cursor: pointer;
 }
 
 .settings .currency-selection .currency-info .icon{

--- a/src/components/Settings.jsx
+++ b/src/components/Settings.jsx
@@ -44,11 +44,19 @@ const Settings = ({settings, setSettings}) => {
                 <div className="currency-dropdown">
                 <Dropdown  options={currencyOptions}
                     onSelect={changeCurrency}
-                    defaultValue={
+                    value={
                         settings.currency
                 }></Dropdown>
                 </div>
-                <div className="currency-info" onMouseOver={handleMouseEnterInfoIcon} onMouseOut={handleMouseLeaveInfoIcon}><img className="icon" src="/information-button.png" alt='i'></img></div>
+                <button
+                    type="button"
+                    className="currency-info"
+                    onMouseOver={handleMouseEnterInfoIcon}
+                    onMouseOut={handleMouseLeaveInfoIcon}
+                    onFocus={handleMouseEnterInfoIcon}
+                    onBlur={handleMouseLeaveInfoIcon}
+                    aria-label="Currency information"
+                ><img className="icon" src="/information-button.png" alt=''></img></button>
             </div>
             {showCurrencyInfo ? <p className="currency-info-box">EUR is currency from original data. For USD historical exchange rate for the corresponding year is used.</p> : ''}
         </div>

--- a/src/components/WorldMap.jsx
+++ b/src/components/WorldMap.jsx
@@ -222,8 +222,10 @@ const WorldMap = ({mapModeImport, year, activeCountryData, updateActiveCountry, 
       </ComposableMap>
       <div className='zoom'>
                 <button className='button'
+                    aria-label="Zoom in"
                     onClick={handleZoomIn}>+</button>
                 <button className='button'
+                    aria-label="Zoom out"
                     onClick={handleZoomOut}>-</button>
             </div>
       {hoveredCountry && (mapModeImport ? MapTooltipImports(hoveredCountry, settings) : MapTooltipExports(hoveredCountry, settings))}


### PR DESCRIPTION
Native <select> for the currency dropdown — Replaced the custom Dropdown.jsx combobox with a native <select>, making it keyboard-operable and screen-reader-friendly for free.

Keyboard-accessible currency info — Made the currency info icon a real <button> that also opens on keyboard focus, not just mouse hover.

Semantic footer buttons — Converted the "Data Sources" and "Impressum" footer links from non-interactive <div onClick>s to real <button> elements, so they're reachable and operable via keyboard.

Icon-only aria-labels — Added aria-labels to the zoom in/out buttons, the settings gear button, and the popup close button, so screen readers announce what they do.