### PR TITLE
fix(ui): add abort controller for stale hover responses

### DIFF
--- a/__tests__/App.test.js
+++ b/__tests__/App.test.js
@@ -13,6 +13,7 @@ jest.mock('../src/components/WorldMap', () => (props) => (
   <div data-testid="world-map">
     {JSON.stringify({ mapModeImport: props.mapModeImport, year: props.year })}
     <button onClick={() => props.onCountrySelect('DE')}>select-country</button>
+    <button onClick={() => props.onCountrySelect('FR')}>select-other-country</button>
   </div>
 ));
 
@@ -108,6 +109,23 @@ test('changing the year while a country is selected refetches its data for the n
   await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(20));
   const urls = fetchMock.mock.calls.map((call) => call[0]);
   expect(urls.filter((u) => u.includes('year=2021')).length).toBeGreaterThan(0);
+});
+
+test('selecting a new country aborts the in-flight fetch for the previous one', async () => {
+  const signals = [];
+  global.fetch = jest.fn((url, options = {}) => {
+    if (options.signal) signals.push(options.signal);
+    return new Promise(() => {}); // never resolves - only the abort behavior is under test
+  });
+
+  render(<App />);
+  fireEvent.click(screen.getByText('select-country'));
+  await waitFor(() => expect(signals.length).toBeGreaterThan(0));
+  const firstSignal = signals[0];
+  expect(firstSignal.aborted).toBe(false);
+
+  fireEvent.click(screen.getByText('select-other-country'));
+  await waitFor(() => expect(firstSignal.aborted).toBe(true));
 });
 
 test('shows a loading indicator while country data is being fetched, then hides it', async () => {

--- a/__tests__/WorldMap.test.js
+++ b/__tests__/WorldMap.test.js
@@ -113,6 +113,43 @@ test('the tooltip follows the current mouse position immediately, not one event 
   expect(tooltip).toHaveStyle({ left: '110px', top: '205px' });
 });
 
+test('hovering again aborts the previous hover fetch instead of letting it resolve later and overwrite the current one', async () => {
+  const signals = [];
+  global.fetch = jest.fn((url, options = {}) => {
+    if (options.signal) signals.push(options.signal);
+    return new Promise(() => {}); // never resolves - only the abort behavior is under test
+  });
+
+  renderMap();
+  const geo = screen.getByTestId('geography');
+
+  fireEvent.mouseOver(geo);
+  await waitFor(() => expect(signals.length).toBeGreaterThan(0));
+  const firstSignal = signals[0];
+  expect(firstSignal.aborted).toBe(false);
+
+  fireEvent.mouseOver(geo);
+  await waitFor(() => expect(firstSignal.aborted).toBe(true));
+});
+
+test('leaving a country aborts its in-flight tooltip fetch', async () => {
+  const signals = [];
+  global.fetch = jest.fn((url, options = {}) => {
+    if (options.signal) signals.push(options.signal);
+    return new Promise(() => {});
+  });
+
+  renderMap();
+  const geo = screen.getByTestId('geography');
+
+  fireEvent.mouseOver(geo);
+  await waitFor(() => expect(signals.length).toBeGreaterThan(0));
+  expect(signals[0].aborted).toBe(false);
+
+  fireEvent.mouseLeave(geo);
+  await waitFor(() => expect(signals[0].aborted).toBe(true));
+});
+
 test('zoom in is clamped so it stabilizes once it reaches the max', () => {
   renderMap();
   const zoomIn = screen.getByText('+');

--- a/__tests__/api.test.js
+++ b/__tests__/api.test.js
@@ -14,7 +14,8 @@ test('builds the request URL from process.env when window._env_ is not set (dev 
   const fetchMock = mockFetchJson(() => ({ value: 'Germany' }));
   await fetchCountryName('DE');
   expect(fetchMock).toHaveBeenCalledWith(
-    'https://api.example.com:443/metadata/name/short?country_code=DE'
+    'https://api.example.com:443/metadata/name/short?country_code=DE',
+    expect.anything()
   );
 });
 
@@ -23,7 +24,8 @@ test('prefers window._env_ over process.env when both are set (prod/runtime conf
   const fetchMock = mockFetchJson(() => ({ value: 'Germany' }));
   await fetchCountryName('DE');
   expect(fetchMock).toHaveBeenCalledWith(
-    'https://runtime.example.com:8443/metadata/name/short?country_code=DE'
+    'https://runtime.example.com:8443/metadata/name/short?country_code=DE',
+    expect.anything()
   );
 });
 
@@ -31,8 +33,16 @@ test('URL-encodes query parameters', async () => {
   const fetchMock = mockFetchJson(() => ({ value: 8.67 }));
   await fetchDemocracyIndex('DE', 2020);
   expect(fetchMock).toHaveBeenCalledWith(
-    'https://api.example.com:443/metadata/democracy_index?country_code=DE&year=2020'
+    'https://api.example.com:443/metadata/democracy_index?country_code=DE&year=2020',
+    expect.anything()
   );
+});
+
+test('forwards an AbortSignal through to fetch, so a caller can cancel a stale request', async () => {
+  const fetchMock = mockFetchJson(() => ({ value: 'Germany' }));
+  const controller = new AbortController();
+  await fetchCountryName('DE', controller.signal);
+  expect(fetchMock).toHaveBeenCalledWith(expect.any(String), { signal: controller.signal });
 });
 
 test('resolves with the parsed JSON body on success', async () => {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,4 @@
-import React, {useState, useEffect, useCallback} from 'react';
+import React, {useState, useEffect, useCallback, useRef} from 'react';
 import WorldMap from './components/WorldMap';
 import YearSlider from './components/YearSlider';
 import ToggleButton from './components/ToggleButton';
@@ -72,6 +72,11 @@ function App() {
     const [isCountryDataLoading, setIsCountryDataLoading] = useState(false);
     const [countryDataError, setCountryDataError] = useState(null);
 
+    // Tracks the in-flight request so a new selection can cancel a slower,
+    // now-stale one instead of letting it resolve later and overwrite
+    // newer data.
+    const countryDataAbortControllerRef = useRef(null);
+
     // Fetches data for the given country. Only called from the effect below,
     // which re-runs whenever the selected country or the year/settings
     // change - callers elsewhere should just call setActiveCountryAlpha2 to
@@ -79,6 +84,11 @@ function App() {
     // bug this replaced: calling this directly *and* relying on the effect
     // fired the whole fetch batch twice per click).
     const fetchCountryData = useCallback(async (alpha2) => {
+        countryDataAbortControllerRef.current?.abort();
+        const controller = new AbortController();
+        countryDataAbortControllerRef.current = controller;
+        const { signal } = controller;
+
         setIsCountryDataLoading(true);
         setCountryDataError(null);
         try {
@@ -96,16 +106,16 @@ function App() {
                 exportTimeSeriesData,
                 merchExportData
             ] = await Promise.all([
-                fetchCountryName(alpha2),
-                fetchDemocracyIndex(alpha2, year),
-                fetchTotalImports(alpha2, year, currency),
-                fetchPeaceIndex(alpha2, year),
-                fetchImportSources(alpha2, year, currency),
-                fetchImportTimeSeries(alpha2, currency),
-                fetchTotalExports(alpha2, year, currency),
-                fetchExportSources(alpha2, year, currency),
-                fetchExportTimeSeries(alpha2, currency),
-                fetchMerchandiseExports(alpha2, year, currency)
+                fetchCountryName(alpha2, signal),
+                fetchDemocracyIndex(alpha2, year, signal),
+                fetchTotalImports(alpha2, year, currency, signal),
+                fetchPeaceIndex(alpha2, year, signal),
+                fetchImportSources(alpha2, year, currency, undefined, signal),
+                fetchImportTimeSeries(alpha2, currency, signal),
+                fetchTotalExports(alpha2, year, currency, signal),
+                fetchExportSources(alpha2, year, currency, undefined, signal),
+                fetchExportTimeSeries(alpha2, currency, signal),
+                fetchMerchandiseExports(alpha2, year, currency, signal)
             ]);
 
             // update object with new data
@@ -124,10 +134,16 @@ function App() {
 
 
         } catch (error) {
+            if (error.name === 'AbortError') return; // superseded by a newer selection, not a real failure
             console.error('Error fetching country data:', error);
             setCountryDataError('Could not load data for this country. Please try again.');
         } finally {
-            setIsCountryDataLoading(false);
+            // Only the still-current request should touch loading state -
+            // otherwise a superseded request's finally could clear it while
+            // the newer request is still legitimately in flight.
+            if (countryDataAbortControllerRef.current === controller) {
+                setIsCountryDataLoading(false);
+            }
         }
     }, [year, settings])
 

--- a/src/api.js
+++ b/src/api.js
@@ -4,6 +4,11 @@
  * or process.env in development - see CLAUDE.md) and query-param encoding,
  * so every caller gets the same request-building and error handling instead
  * of each hand-rolling its own fetch calls.
+ *
+ * Every function takes an optional AbortSignal as its last argument, so
+ * callers can cancel a stale, still-in-flight request (e.g. the user
+ * hovered/clicked a different country before the previous one resolved)
+ * instead of letting it resolve later and overwrite newer data.
  */
 
 const getApiHost = () =>
@@ -19,40 +24,40 @@ const buildUrl = (path, params) => {
     return `https://${getApiHost()}:${getApiPort()}${path}?${query}`;
 };
 
-const apiFetch = async (path, params) => {
-    const response = await fetch(buildUrl(path, params));
+const apiFetch = async (path, params, signal) => {
+    const response = await fetch(buildUrl(path, params), { signal });
     if (!response.ok) {
         throw new Error(`Request to ${path} failed with status ${response.status}`);
     }
     return response.json();
 };
 
-export const fetchCountryName = (countryCode) =>
-    apiFetch('/metadata/name/short', { country_code: countryCode });
+export const fetchCountryName = (countryCode, signal) =>
+    apiFetch('/metadata/name/short', { country_code: countryCode }, signal);
 
-export const fetchDemocracyIndex = (countryCode, year) =>
-    apiFetch('/metadata/democracy_index', { country_code: countryCode, year });
+export const fetchDemocracyIndex = (countryCode, year, signal) =>
+    apiFetch('/metadata/democracy_index', { country_code: countryCode, year }, signal);
 
-export const fetchPeaceIndex = (countryCode, year) =>
-    apiFetch('/metadata/peace_index', { country_code: countryCode, year });
+export const fetchPeaceIndex = (countryCode, year, signal) =>
+    apiFetch('/metadata/peace_index', { country_code: countryCode, year }, signal);
 
-export const fetchTotalImports = (countryCode, year, currency) =>
-    apiFetch('/arms/imports/total', { country_code: countryCode, year, currency });
+export const fetchTotalImports = (countryCode, year, currency, signal) =>
+    apiFetch('/arms/imports/total', { country_code: countryCode, year, currency }, signal);
 
-export const fetchImportSources = (countryCode, year, currency, limit = 20) =>
-    apiFetch('/arms/imports/by_country', { country_code: countryCode, year, limit, currency });
+export const fetchImportSources = (countryCode, year, currency, limit = 20, signal) =>
+    apiFetch('/arms/imports/by_country', { country_code: countryCode, year, limit, currency }, signal);
 
-export const fetchImportTimeSeries = (countryCode, currency) =>
-    apiFetch('/arms/imports/timeseries', { country_code: countryCode, currency });
+export const fetchImportTimeSeries = (countryCode, currency, signal) =>
+    apiFetch('/arms/imports/timeseries', { country_code: countryCode, currency }, signal);
 
-export const fetchTotalExports = (countryCode, year, currency) =>
-    apiFetch('/arms/exports/total', { country_code: countryCode, year, currency });
+export const fetchTotalExports = (countryCode, year, currency, signal) =>
+    apiFetch('/arms/exports/total', { country_code: countryCode, year, currency }, signal);
 
-export const fetchExportSources = (countryCode, year, currency, limit = 5) =>
-    apiFetch('/arms/exports/by_country', { country_code: countryCode, year, limit, currency });
+export const fetchExportSources = (countryCode, year, currency, limit = 5, signal) =>
+    apiFetch('/arms/exports/by_country', { country_code: countryCode, year, limit, currency }, signal);
 
-export const fetchExportTimeSeries = (countryCode, currency) =>
-    apiFetch('/arms/exports/timeseries', { country_code: countryCode, currency });
+export const fetchExportTimeSeries = (countryCode, currency, signal) =>
+    apiFetch('/arms/exports/timeseries', { country_code: countryCode, currency }, signal);
 
-export const fetchMerchandiseExports = (countryCode, year, currency) =>
-    apiFetch('/merchandise/exports/total', { country_code: countryCode, year, currency });
+export const fetchMerchandiseExports = (countryCode, year, currency, signal) =>
+    apiFetch('/merchandise/exports/total', { country_code: countryCode, year, currency }, signal);

--- a/src/components/WorldMap.jsx
+++ b/src/components/WorldMap.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useRef } from 'react';
 import { ComposableMap, Geographies, Geography, ZoomableGroup } from 'react-simple-maps';
 import MapTooltipImports from './MapTooltipImports';
 import MapTooltipExports from './MapTooltipExports';
@@ -54,6 +54,11 @@ const WorldMap = ({mapModeImport, year, activeCountryData, onCountrySelect, sett
   const [hoveredCountry, setHoveredCountry] = useState(null);
   const [mousePosition, setMousePosition] = useState({ x: 0, y: 0 });
 
+  // Tracks the in-flight tooltip request so hovering a new country (or
+  // leaving one) can cancel a slower, now-stale one instead of letting it
+  // resolve later and overwrite the current tooltip.
+  const tooltipAbortControllerRef = useRef(null);
+
 
   // Track mouse over the map background. handleMouseMoveOnGeo (below) calls
   // stopPropagation while hovering a Geography, so this only ever fires
@@ -89,14 +94,19 @@ const WorldMap = ({mapModeImport, year, activeCountryData, onCountrySelect, sett
   // Get data for the tooltip if map mode is import
   const getImportTooltipData = async (alpha2) => {
 
+    tooltipAbortControllerRef.current?.abort();
+    const controller = new AbortController();
+    tooltipAbortControllerRef.current = controller;
+    const { signal } = controller;
+
     try {
       const currency = settings.currency.value;
 
       const [countryName, democracyIndex, totalArmsImports, peaceIndex] = await Promise.all([
-        fetchCountryName(alpha2),
-        fetchDemocracyIndex(alpha2, year),
-        fetchTotalImports(alpha2, year, currency),
-        fetchPeaceIndex(alpha2, year)
+        fetchCountryName(alpha2, signal),
+        fetchDemocracyIndex(alpha2, year, signal),
+        fetchTotalImports(alpha2, year, currency, signal),
+        fetchPeaceIndex(alpha2, year, signal)
       ]);
 
       const data = {
@@ -109,20 +119,26 @@ const WorldMap = ({mapModeImport, year, activeCountryData, onCountrySelect, sett
       setHoveredCountry({...data, position: mousePosition});
 
     } catch (error) {
+      if (error.name === 'AbortError') return; // superseded by a newer hover, not a real failure
       console.error('Error fetching country data:', error);
     }
-  } 
+  }
 
   // Get data for tooltuip if map mode export
   const getExportTooltipData = async (alpha2) => {
+
+    tooltipAbortControllerRef.current?.abort();
+    const controller = new AbortController();
+    tooltipAbortControllerRef.current = controller;
+    const { signal } = controller;
 
     try {
       const currency = settings.currency.value;
 
       const [countryName, totalArmsExports, totalMerchExports] = await Promise.all([
-        fetchCountryName(alpha2),
-        fetchTotalExports(alpha2, year, currency),
-        fetchMerchandiseExports(alpha2, year, currency)
+        fetchCountryName(alpha2, signal),
+        fetchTotalExports(alpha2, year, currency, signal),
+        fetchMerchandiseExports(alpha2, year, currency, signal)
       ]);
 
       const data = {
@@ -134,6 +150,7 @@ const WorldMap = ({mapModeImport, year, activeCountryData, onCountrySelect, sett
       setHoveredCountry({...data, position: mousePosition});
 
     } catch (error) {
+      if (error.name === 'AbortError') return; // superseded by a newer hover, not a real failure
       console.error('Error fetching country data:', error);
       throw error; // Rethrow the error to indicate that an error occurred
     }
@@ -142,6 +159,7 @@ const WorldMap = ({mapModeImport, year, activeCountryData, onCountrySelect, sett
 
   // Remove hover tool when leaving geometry
   const handleCountryLeave = (event) => {
+    tooltipAbortControllerRef.current?.abort();
     setHoveredCountry(null)
     event.target.setAttribute('fill', defaultColor);
   };


### PR DESCRIPTION
AbortController`/request-id guard so a slow, stale hover response can't overwrite a newer one.